### PR TITLE
Allow Test deployment to be run manually

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -1,6 +1,7 @@
 name: Test deployment
 
 on:
+    workflow_dispatch:
     pull_request:
         branches:
             - main


### PR DESCRIPTION
Before this change, you had to submit a change as a pull request just to run the test deployment workflow. This can be kind of annoying. Consider PR #9 for example. The changes from #9 worked fine on my system, but the test deployment workflow for #9 was failing. I wanted to try several different fixes before submitting a corrected version of the PR. I had to test out multiple different things before I found something that actually works. It was really annoying to try and get the test deployment workflow to run without pushing to my PR branch.

I could have just pushed my code to the PR branch, but every time you push to a PR branch, it sends an email to everyone who is subscribed to the PR. I want to be able to test out my changes in CI without spamming people with emails.