### PR TITLE
Rewrite build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,108 @@ The repo holds the source code for the SmartKids Docs. If you want to contribute
 
 ## Building and previewing the site locally
 
-Assuming [NodeJS](https://nodejs.org) and [Yarn](https://yarnpkg.com/) are installed on your computer:
+1. Open a terminal.
 
-1.  Change your working directory to the root directory of your site.
+2. If you do not use [the Nix package manager](https://nix.dev), then make sure that you have [Corepack](https://nodejs.org/docs/latest/api/corepack.html) installed by running this command:
 
-2.  Run `yarn` to install dependencies
+    ```
+    corepack --version
+    ```
 
-3.  Run `yarn start`
+    If that command displays a version number, then you’re good. If that command gives you an error, then you can get Corepack by [installing Node.js](https://nodejs.org/en/learn/getting-started/how-to-install-nodejs).
 
-This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
+    **Note:** If you choose to install Node.js using a package manager, then be careful. Not all Node.js packages contain the `corepack` command. For example, [Homebrew’s `node` package](https://formulae.brew.sh/formula/node) contains the `node` command, but it does not contain the `corepack` command. Homebrew users need to install [Homebrew’s `corepack` package](https://formulae.brew.sh/formula/corepack) in order to get the `corepack` command.
+
+    **Note:** If you’re using Windows and you don’t already have Corepack, then you will need to close out of your terminal window and reopen it after everything has finished installing.
+
+3. Make sure that you have a copy of this repo on your computer. If you aren’t sure how to do this, then please take a look at [this guide](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository
+).
+
+4. Change directory into the root of the repo by running this command:
+
+    ```
+    cd <path-to-smartkidsllc.github.io-repo>
+    ```
+
+5. Make sure that Corepack is enabled.
+
+    - If you use the Nix package manager, then start a new development shell that has Corepack enabled by running this command:
+
+        ```
+        nix \
+            --extra-experimental-features nix-command \
+            --extra-experimental-features flakes \
+            develop
+        ```
+
+    - If you do not use the Nix package manager, then ensure that Corepack is enabled by running this command:
+
+        ```
+        corepack enable
+        ```
+
+        That command may give you one of these two errors:
+
+        ```
+        Internal Error: EACCES: permission denied…
+        Internal Error: EPERM: operation not permitted…
+        ```
+
+        <details>
+        <summary>If you get that error, then try enabling Corepack as an administrator (click here to show details).</summary>
+
+        - If you’re using Windows, then do the following:
+
+            1. Open a new Administrator Command Prompt window. If you aren’t sure how to do this, then please take a look at [this guide](https://www.howtogeek.com/194041/how-to-open-the-command-prompt-as-administrator-in-windows-10/).
+
+            2. In the Administrator Command Prompt window, try enabling Corepack again by running this command:
+
+                ```
+                corepack enable
+                ```
+
+            3. Once that command finishes successfully, close out of the Administrator Command Prompt window.
+
+            4. Go back to the terminal window that you opened earlier.
+
+        - If you’re not using Windows, then run the following command:
+
+            ```
+            sudo corepack enable
+            ```
+
+        </details>
+
+6. Make sure that all of the site’s dependencies are installed by running this command:
+
+    ```
+    yarn
+    ```
+
+7. If you see a prompt that looks like this,
+
+    ```
+    ! Corepack is about to download https://repo.yarnpkg.com/4.4.0/packages/yarnpkg-cli/bin/yarn.js
+    ? Do you want to continue? [Y/n]
+    ```
+
+    then press <kbd>Y</kbd> followed by <kbd>Enter</kbd>.
+
+8. Open a Web browser with a preview of what the site will look like by running this command:
+
+    ```
+    yarn start
+    ```
+
+9. Once you’re done previewing the site, stop the development server by going back to your terminal and pressing <kbd><kbd>Ctrl</kbd>+<kbd>C</kbd></kbd>.
+
+10. If you see a prompt that looks like this,
+
+    ```
+    Terminate batch job (Y/N)?
+    ```
+
+    then press <kbd>N</kbd> followed by <kbd>Enter</kbd>.
 
 ## Contributing
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1724727824,
+        "narHash": "sha256-0XH9MJk54imJm+RHOLTUJ7e+ponLW00tw5ke4MTVa1Y=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "36bae45077667aff5720e5b3f1a5458f51cf0776",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,27 @@
+{
+  description = "A flake for working on smartkidsllc.github.io";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      devShellsFor =
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        {
+          "${system}".default = pkgs.mkShellNoCC {
+            name = "shell-for-working-on-smartkidsllc.github.io";
+            packages = [ pkgs.corepack ];
+          };
+        };
+    in
+    {
+      # This is a workaround for this issue:
+      # <https://github.com/NixOS/nix/issues/3843>
+      devShells =
+        (devShellsFor "aarch64-darwin") // (devShellsFor "x86_64-darwin") // (devShellsFor "x86_64-linux");
+    };
+}


### PR DESCRIPTION
See the commit messages for details.

I’ve tested the proposed instructions and can confirm that they work in these situations:

- A fresh install of [Arch Linux](https://archlinux.org) with Node.js installed via the system package manager
- A fresh install of [Fedora] 40 with Node.js installed via a package manager that [nodejs.org](https://nodejs.org) recommends ([fnm](https://fnm.vercel.app))
- A fresh install of [Fedora] 40 with Node.js installed via [Homebrew](https://brew.sh)
- A fresh install of [NixOS](https://nixos.org) with Node.js installed via the Nix package manager.
- A fresh install of Windows 10 with Node.js installed via the Node.js installer.

I would be interested in getting feedback for @clayton14 since I know that he tried the current build instructions and that the instructions didn’t work for him. I would also be good if someone tested the proposed instructions on macOS.

[Fedora]: https://fedoraproject.org
